### PR TITLE
fix: Support Seerr webhook payload format

### DIFF
--- a/language-tagger/webhook_server.py
+++ b/language-tagger/webhook_server.py
@@ -109,6 +109,13 @@ class WebhookServer:
                 return False, "Missing or invalid 'media' field"
 
             tmdb_id = media.get('tmdbId')
+            # Seerr/Overseerr may send tmdbId as string or int - handle both
+            if isinstance(tmdb_id, str):
+                try:
+                    tmdb_id = int(tmdb_id)
+                except (ValueError, TypeError):
+                    return False, "Invalid 'media.tmdbId' field (cannot convert to integer)"
+
             if not isinstance(tmdb_id, int) or tmdb_id <= 0:
                 return False, "Missing or invalid 'media.tmdbId' field (must be positive integer)"
 


### PR DESCRIPTION
Fixes webhook integration with Seerr by handling tmdbId as string.

## Changes
- Handle tmdbId as both string and integer in validation
- Seerr sends `"293670"` (string), Overseerr sends `293670` (int)
- Added conversion logic to handle both formats

## Testing
✅ Webhook authentication working  
✅ Payload validation passing  
✅ Language detection (Korean → Dub Preferred)  
✅ Tag assignment (prefer-dub)  
✅ Automatic search triggered  

**Test case:** "The Wailing" (TMDB 293670)
- Language: Korean
- Profile assigned: Dub Preferred
- Tag added: prefer-dub
- Search triggered: Movie ID 2123

## Logs
```
2025-11-30 22:15:06 - Received webhook: MEDIA_AUTO_APPROVED
2025-11-30 22:15:06 - Processing webhook for movie TMDB 293670
2025-11-30 22:15:07 - movie TMDB 293670: ko → Dub Preferred
2025-11-30 22:15:07 - Found movie 'The Wailing' (ID 2123)
2025-11-30 22:15:07 - Updating 'The Wailing' [Korean]: add tag 'prefer-dub', set profile to 'Dub Preferred'
2025-11-30 22:15:09 - ✓ Triggered search for movie ID 2123
```

Closes webhook compatibility issue with Seerr.