### PR TITLE
refactor: Move audio_tags config inline with instance config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,8 @@ Example config structure at `language-tagger/config.yml`
 schedule:
   interval_hours: 24
   run_on_startup: true
+  audio_scan_interval_hours: 24   # Optional: separate interval for audio tagging
+  audio_scan_on_startup: true
 
 webhook:
   enabled: true
@@ -148,24 +150,11 @@ radarr:
     min_search_interval_seconds: 5
 
 sonarr:
-  main:  # Same structure as radarr
-
-audio_tags:
-  enabled: true
-  scan_interval_hours: 24
-  scan_on_startup: true
-  radarr:
-    main:
-      tags:
-        - language: de
-          tag_name: german-audio
-        - language: en
-          tag_name: english-audio
-  sonarr:
-    main:
-      tags:
-        - language: de
-          tag_name: german-audio
+  main:
+    # Same structure as radarr, plus optional audio_tags:
+    audio_tags:
+      - language: de
+        tag_name: german-audio
 ```
 
 ### Environment Variable Patterns
@@ -260,6 +249,17 @@ Separate from profile assignment, audio tagging inspects downloaded files:
 3. Normalizes language names using `LANGUAGE_ALIASES` mapping
 4. Adds configured tags (e.g., `german-audio`) if language is detected
 5. Removes tags if language is no longer present (file replaced)
+
+**Configuration:** Add `audio_tags` list to any radarr/sonarr instance config:
+```yaml
+radarr:
+  main:
+    audio_tags:
+      - language: de
+        tag_name: german-audio
+```
+
+**Schedule settings** in `schedule` section: `audio_scan_interval_hours`, `audio_scan_on_startup`
 
 **Use case:** Tag all content that has German audio, regardless of original language. Useful for filtering in Plex/Jellyfin.
 

--- a/README.md
+++ b/README.md
@@ -226,26 +226,27 @@ Tag media based on **actual audio tracks** in downloaded files, not just origina
 
 ### Setup
 
-Add to `config.yml`:
+Add `audio_tags` to your instance config in `config.yml`:
 ```yaml
-audio_tags:
-  enabled: true
-  scan_interval_hours: 24    # How often to scan (default: 24)
-  scan_on_startup: true      # Scan on startup (default: true)
+schedule:
+  interval_hours: 24
+  audio_scan_interval_hours: 24  # Optional: separate interval for audio scanning
 
-  radarr:
-    main:                    # Must match your radarr instance name
-      tags:
-        - language: de       # ISO code or full name
-          tag_name: german-audio
-        - language: en
-          tag_name: english-audio
+radarr:
+  main:
+    # ...existing config...
+    audio_tags:              # Add this section
+      - language: de         # ISO code or full name
+        tag_name: german-audio
+      - language: en
+        tag_name: english-audio
 
-  sonarr:
-    main:
-      tags:
-        - language: de
-          tag_name: german-audio
+sonarr:
+  main:
+    # ...existing config...
+    audio_tags:
+      - language: de
+        tag_name: german-audio
 ```
 
 ### How It Works

--- a/language-tagger/config.example.yml
+++ b/language-tagger/config.example.yml
@@ -9,6 +9,9 @@
 schedule:
   interval_hours: 24
   run_on_startup: true
+  # Audio track tagging schedule (only used if audio_tags configured in instances)
+  audio_scan_interval_hours: 24   # How often to scan for audio tracks (default: 24)
+  audio_scan_on_startup: true     # Scan audio tracks on startup (default: true)
 
 # ============================================================================
 # WEBHOOK SERVER (OPTIONAL - for real-time Seerr/Overseerr integration)
@@ -70,6 +73,17 @@ radarr:
     search_cooldown_seconds: 60         # Don't search same item within 60s (default: 60)
     min_search_interval_seconds: 5      # Min time between ANY searches (default: 5)
 
+    # Audio Track Tagging (OPTIONAL)
+    # Tags media based on actual audio tracks in downloaded files.
+    # Use case: Tag all movies with German audio, regardless of original language.
+    audio_tags:
+      - language: de        # ISO 639-1 code or full name (German, English, etc.)
+        tag_name: german-audio
+      - language: en
+        tag_name: english-audio
+      # - language: fr
+      #   tag_name: french-audio
+
   # Example: 4K instance (uncomment and configure if needed)
   # 4k:
   #   enabled: true
@@ -83,6 +97,9 @@ radarr:
   #   trigger_search_on_update: true
   #   search_cooldown_seconds: 60
   #   min_search_interval_seconds: 5
+  #   audio_tags:
+  #     - language: de
+  #       tag_name: german-audio
 
 # ============================================================================
 # SONARR INSTANCES
@@ -104,6 +121,15 @@ sonarr:
     search_cooldown_seconds: 60         # Don't search same item within 60s (default: 60)
     min_search_interval_seconds: 5      # Min time between ANY searches (default: 5)
 
+    # Audio Track Tagging (OPTIONAL)
+    # Tags series based on actual audio tracks in downloaded episodes.
+    # Series is tagged if ANY episode has the audio track.
+    audio_tags:
+      - language: de
+        tag_name: german-audio
+      - language: en
+        tag_name: english-audio
+
   # Example: Anime instance (uncomment and configure if needed)
   # anime:
   #   enabled: true
@@ -116,40 +142,6 @@ sonarr:
   #   trigger_search_on_update: true
   #   search_cooldown_seconds: 60
   #   min_search_interval_seconds: 5
-
-# ============================================================================
-# AUDIO TRACK TAGGING (OPTIONAL - tag media based on actual audio tracks)
-# ============================================================================
-# Scans downloaded files and adds tags based on detected audio languages.
-# Unlike profile assignment (which uses original language metadata), this
-# inspects the actual mediaInfo of imported files.
-#
-# Use case: Tag all movies/shows that have a German audio track, regardless
-# of the content's original language.
-audio_tags:
-  enabled: false              # Set to true to enable audio track tagging
-  scan_interval_hours: 24     # How often to scan for new files (default: 24)
-  scan_on_startup: true       # Scan immediately on startup (default: true)
-
-  # Language-to-tag mappings for Radarr
-  # Scans movieFile.mediaInfo.audioLanguages for each language
-  radarr:
-    main:                     # Must match instance name in radarr section above
-      tags:
-        - language: de        # Language to detect (ISO 639-1 code or full name)
-          tag_name: german-audio
-        - language: en
-          tag_name: english-audio
-        # Add more language/tag pairs as needed
-        # - language: fr
-        #   tag_name: french-audio
-
-  # Language-to-tag mappings for Sonarr
-  # Scans episodeFile.mediaInfo.audioLanguages for each episode
-  sonarr:
-    main:                     # Must match instance name in sonarr section above
-      tags:
-        - language: de
-          tag_name: german-audio
-        - language: en
-          tag_name: english-audio
+  #   audio_tags:
+  #     - language: ja
+  #       tag_name: japanese-audio


### PR DESCRIPTION
## Summary

Refactors audio tag configuration to be inline with each instance, eliminating redundant instance name repetition.

## Changes

**Before:**
```yaml
radarr:
  main:
    # config...

audio_tags:
  radarr:
    main:  # duplicated
      tags: [...]
```

**After:**
```yaml
schedule:
  audio_scan_interval_hours: 24

radarr:
  main:
    # config...
    audio_tags:  # inline
      - language: de
        tag_name: german-audio
```

## Benefits

- No duplication of instance names
- All instance config in one place
- Schedule settings in global schedule section
- Cleaner, more intuitive structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)