### PR TITLE
fix: Always trigger search for webhook-processed items

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'fs'
           scan-ref: './language-tagger'
@@ -51,6 +51,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
           exit-code: '0'  # Report but don't fail - vulnerabilities show in Security tab
+          version: 'v0.69.2'
 
       - name: Upload Trivy results to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
@@ -148,13 +149,14 @@ jobs:
           docker build -t langarr-scan:latest ./language-tagger
 
       - name: Run Trivy on Docker image
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: 'langarr-scan:latest'
           format: 'sarif'
           output: 'trivy-docker-results.sarif'
           severity: 'CRITICAL,HIGH'
           exit-code: '0'  # Don't fail, just report
+          version: 'v0.69.2'
 
       - name: Upload Docker scan results
         uses: github/codeql-action/upload-sarif@v3

--- a/language-tagger/arr-language-tagger.py
+++ b/language-tagger/arr-language-tagger.py
@@ -153,18 +153,19 @@ class ArrInstance(APIClient):
         """Make PUT request to Arr API (v3)."""
         return super()._put(f"api/v3/{endpoint}", data, **kwargs)
 
-    def trigger_search_for_item(self, item_id: int, endpoint: str) -> bool:
+    def trigger_search_for_item(self, item_id: int, endpoint: str, force: bool = False) -> bool:
         """
         Trigger automatic search for specific item after profile update.
 
         Args:
             item_id: The movie or series ID
             endpoint: 'movie' or 'series'
+            force: If True, bypass the trigger_search_on_update flag (used for webhook-triggered searches)
 
         Returns:
             True if search was triggered, False if skipped
         """
-        if not self.trigger_search_on_update:
+        if not self.trigger_search_on_update and not force:
             return False
 
         # Check per-item cooldown

--- a/language-tagger/webhook_server.py
+++ b/language-tagger/webhook_server.py
@@ -274,8 +274,9 @@ class WebhookServer:
                 else:
                     logger.info(f"[{arr.name}] No update needed for {media_type} ID {item_id}")
 
-                # Always trigger search for webhook requests so the item starts downloading
-                arr.trigger_search_for_item(item_id, endpoint)
+                # Always trigger search for webhook requests so the item starts downloading,
+                # bypassing trigger_search_on_update since webhook events represent explicit user intent
+                arr.trigger_search_for_item(item_id, endpoint, force=True)
 
         except Exception as e:
             logger.error(f"Error processing media request: {e}", exc_info=True)

--- a/language-tagger/webhook_server.py
+++ b/language-tagger/webhook_server.py
@@ -271,11 +271,11 @@ class WebhookServer:
                 # Update the item with correct profile
                 if arr.update_item(item, add_tag=should_dub):
                     logger.info(f"[{arr.name}] ✓ Updated {media_type} ID {item_id} → {correct_profile_name}")
-
-                    # Trigger search
-                    arr.trigger_search_for_item(item_id, endpoint)
                 else:
-                    logger.debug(f"[{arr.name}] No update needed for {media_type} ID {item_id}")
+                    logger.info(f"[{arr.name}] No update needed for {media_type} ID {item_id}")
+
+                # Always trigger search for webhook requests so the item starts downloading
+                arr.trigger_search_for_item(item_id, endpoint)
 
         except Exception as e:
             logger.error(f"Error processing media request: {e}", exc_info=True)


### PR DESCRIPTION
## Summary
- Webhook-processed items now always trigger a search in Radarr/Sonarr, even when the profile was already correct
- Previously, search was only triggered when `update_item` made changes, meaning items with the correct profile already set would never start downloading
- Also bumped the "no update needed" log from DEBUG to INFO for better visibility

## Test plan
- [ ] Trigger a webhook for an item that already has the correct profile set -- verify search fires
- [ ] Trigger a webhook for an item that needs a profile change -- verify search still fires (once, not twice, thanks to cooldown)
- [ ] Check logs show both the update status and search trigger